### PR TITLE
Fixed @ CVE-2020-15366

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,12 +32,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.8.3"
+				"@babel/highlight": "^7.10.4"
 			}
 		},
 		"node_modules/@babel/core": {
@@ -147,9 +147,9 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-			"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^2.0.0",
@@ -1859,12 +1859,12 @@
 			}
 		},
 		"node_modules/acorn-jsx": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
 			"peerDependencies": {
-				"acorn": "^6.0.0 || ^7.0.0"
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/acorn-walk": {
@@ -1877,9 +1877,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -3606,9 +3606,9 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -3656,24 +3656,24 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
 			"dev": true,
 			"dependencies": {
-				"estraverse": "^4.0.0"
+				"estraverse": "^5.1.0"
 			},
 			"engines": {
 				"node": ">=0.6"
 			}
 		},
 		"node_modules/esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"dependencies": {
-				"estraverse": "^4.1.0"
+				"estraverse": "^5.2.0"
 			},
 			"engines": {
 				"node": ">=4.0"
@@ -4112,9 +4112,9 @@
 			]
 		},
 		"node_modules/fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
 		"node_modules/fast-json-stable-stringify": {
@@ -9876,10 +9876,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true
 		},
 		"node_modules/require-uncached": {
@@ -9895,10 +9895,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/require-uncached/node_modules/resolve-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -9967,18 +9967,18 @@
 			}
 		},
 		"node_modules/rewire": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
-			"integrity": "sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rewire/-/rewire-6.0.0.tgz",
+			"integrity": "sha512-7sZdz5dptqBCapJYocw9EcppLU62KMEqDLIILJnNET2iqzXHaQfaVP5SOJ06XvjX+dNIDJbzjw0ZWzrgDhtjYg==",
 			"dev": true,
 			"dependencies": {
-				"eslint": "^4.19.1"
+				"eslint": "^7.32.0"
 			}
 		},
 		"node_modules/rewire/node_modules/acorn": {
-			"version": "5.7.4",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -9987,22 +9987,22 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/rewire/node_modules/acorn-jsx": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+		"node_modules/rewire/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
-			"dependencies": {
-				"acorn": "^3.0.4"
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"node_modules/rewire/node_modules/acorn-jsx/node_modules/acorn": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-			"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+		"node_modules/rewire/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
-			"bin": {
-				"acorn": "bin/acorn"
+			"dependencies": {
+				"color-convert": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=0.4.0"


### PR DESCRIPTION
An issue was discovered in ajv.validate() in Ajv (aka Another JSON Schema Validator) 6.12.2. A carefully crafted JSON schema could be provided that allows execution of other code by prototype pollution. (While untrusted schemas are recommended against, the worst case of an untrusted schema should be a denial of service, not execution of code.)


CVE-2020-15366
`CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L`
GHSA-v88g-cgmw-v5xw
